### PR TITLE
Stop showing OGP

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -55,6 +55,7 @@ steps:
             <<# parameters.talk-id >>
             -d "talkIds[0]=<< parameters.talk-id >>" \
             <</ parameters.talk-id >>
+            -d "showLinkMeta=false" \
             -o /dev/null \
             "https://typetalk.com/api/v1/topics/<< parameters.topic-id>>"
         fi

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -88,6 +88,7 @@ steps:
                   <<# parameters.talk-id >>
                   -d "talkIds[0]=<< parameters.talk-id >>" \
                   <</ parameters.talk-id >>
+                  -d "showLinkMeta=false" \
                   -o /dev/null \
                   "https://typetalk.com/api/v1/topics/<< parameters.topic-id>>"
                 echo "Job completed successfully. Alert sent."
@@ -101,6 +102,7 @@ steps:
                 <<# parameters.talk-id >>
                 -d "talkIds[0]=<< parameters.talk-id >>" \
                 <</ parameters.talk-id >>
+                -d "showLinkMeta=false" \
                 -o /dev/null \
                 "https://typetalk.com/api/v1/topics/<< parameters.topic-id>>"
               echo "Job failed. Alert sent."


### PR DESCRIPTION
Typetalk API is supporting to not show OGP using `showLinkMeta` parameter.